### PR TITLE
Backup per-project access control teams

### DIFF
--- a/weblate_schemas/schemas/weblate-backup.schema.json
+++ b/weblate_schemas/schemas/weblate-backup.schema.json
@@ -292,6 +292,123 @@
       "items": {
         "$ref": "#/definitions/category"
       }
+    },
+    "teams": {
+      "$id": "#root/teams",
+      "title": "Teams",
+      "type": "array",
+      "default": [],
+      "items": {
+        "$id": "#root/teams/items",
+        "title": "Team",
+        "type": "object",
+        "required": [
+          "name",
+          "roles",
+          "components",
+          "language_selection",
+          "languages",
+          "admins",
+          "enforced_2fa",
+          "members",
+          "autogroups"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "$id": "#root/teams/items/name",
+            "title": "Team name",
+            "type": "string",
+            "default": "",
+            "examples": [
+              "My Team"
+            ]
+          },
+          "roles": {
+            "$id": "#root/teams/items/roles",
+            "title": "Roles",
+            "type": "array",
+            "items": {
+              "title": "Role name",
+              "type": "string"
+            },
+            "default": [],
+            "examples": [
+              ["my-role"]
+            ]
+          },
+          "components": {
+            "$id": "#root/teams/items/components",
+            "title": "Components",
+            "type": "array",
+            "items": {
+              "title": "Full component slug excluding the project slug",
+              "type": "string"
+            },
+            "default": [],
+            "examples": []
+          },
+          "language_selection": {
+            "$id": "#root/teams/items/language_selection",
+            "title": "Language Selection",
+            "type": "integer",
+            "enum": [
+              0,
+              1
+            ],
+            "default": 0
+          },
+          "languages": {
+            "$id": "#root/teams/items/languages",
+            "title": "Languages",
+            "type": "array",
+            "items": {
+              "title": "Language code",
+              "type": "string"
+            },
+            "default": [],
+            "examples": []
+          },
+          "admins": {
+            "$id": "#root/teams/items/admins",
+            "title": "Admins",
+            "type": "array",
+            "items": {
+              "title": "Username",
+              "type": "string"
+            },
+            "examples": []
+          },
+          "enforced_2fa": {
+            "$id": "#root/teams/items/enforced_2fa",
+            "title": "Enforced two-factor authentication",
+            "type": "boolean",
+            "default": false
+          },
+          "members": {
+            "$id": "#root/teams/items/members",
+            "title": "Members",
+            "type": "array",
+            "items": {
+              "title": "Username",
+              "type": "string"
+            },
+            "examples": []
+          },
+          "autogroups": {
+            "$id": "#root/teams/items/autogroups",
+            "title": "Auto Groups",
+            "type": "array",
+            "items": {
+              "title": "Regex to match",
+              "type": "string"
+            },
+            "examples": [
+                ["^.*$"]
+            ]
+          }
+        }
+      }
     }
   }
 }

--- a/weblate_schemas/schemas/weblate-backup.schema.json
+++ b/weblate_schemas/schemas/weblate-backup.schema.json
@@ -334,7 +334,10 @@
             },
             "default": [],
             "examples": [
-              ["Translate", "Billing"]
+              [
+                "Translate",
+                "Billing"
+              ]
             ]
           },
           "components": {
@@ -373,7 +376,10 @@
             },
             "default": [],
             "examples": [
-              ["en", "ru"]
+              [
+                "en",
+                "ru"
+              ]
             ]
           },
           "admins": {
@@ -386,7 +392,9 @@
             },
             "default": [],
             "examples": [
-              ["admin"]
+              [
+                "admin"
+              ]
             ]
           },
           "enforced_2fa": {
@@ -405,7 +413,9 @@
             },
             "default": [],
             "examples": [
-              ["user-1"]
+              [
+                "user-1"
+              ]
             ]
           },
           "autogroups": {
@@ -417,7 +427,9 @@
               "type": "string"
             },
             "examples": [
-                ["^.*$"]
+              [
+                "^.*$"
+              ]
             ]
           }
         }

--- a/weblate_schemas/schemas/weblate-backup.schema.json
+++ b/weblate_schemas/schemas/weblate-backup.schema.json
@@ -334,7 +334,7 @@
             },
             "default": [],
             "examples": [
-              ["my-role"]
+              ["Translate", "Billing"]
             ]
           },
           "components": {
@@ -342,11 +342,16 @@
             "title": "Components",
             "type": "array",
             "items": {
-              "title": "Full component slug excluding the project slug",
+              "title": "Full component URL slug excluding the project slug",
               "type": "string"
             },
             "default": [],
-            "examples": []
+            "examples": [
+              [
+                "my-category/my-component",
+                "top-level-component"
+              ]
+            ]
           },
           "language_selection": {
             "$id": "#root/teams/items/language_selection",
@@ -367,7 +372,9 @@
               "type": "string"
             },
             "default": [],
-            "examples": []
+            "examples": [
+              ["en", "ru"]
+            ]
           },
           "admins": {
             "$id": "#root/teams/items/admins",
@@ -377,7 +384,10 @@
               "title": "Username",
               "type": "string"
             },
-            "examples": []
+            "default": [],
+            "examples": [
+              ["admin"]
+            ]
           },
           "enforced_2fa": {
             "$id": "#root/teams/items/enforced_2fa",
@@ -393,7 +403,10 @@
               "title": "Username",
               "type": "string"
             },
-            "examples": []
+            "default": [],
+            "examples": [
+              ["user-1"]
+            ]
           },
           "autogroups": {
             "$id": "#root/teams/items/autogroups",

--- a/weblate_schemas/tests/test_valid.py
+++ b/weblate_schemas/tests/test_valid.py
@@ -124,46 +124,26 @@ def test_backup():
     backup_with_teams["teams"] = [
         {
             "name": "English Translation Team",
-            "roles": [
-                "Translate"
-            ],
-            "components": [
-                "my-category/test-component",
-                "glossary"
-            ],
+            "roles": ["Translate"],
+            "components": ["my-category/test-component", "glossary"],
             "language_selection": 0,
-            "languages": [
-                "en",
-                "en_CA",
-                "ang",
-                "en_IN",
-                "en_GB"
-            ],
+            "languages": ["en", "en_CA", "ang", "en_IN", "en_GB"],
             "admins": [],
             "enforced_2fa": False,
             "members": [],
-            "autogroups": [
-                "^.*$"
-            ]
+            "autogroups": ["^.*$"],
         },
         {
             "name": "Administration",
-            "roles": [
-                "Administration",
-                "Manage languages"
-            ],
+            "roles": ["Administration", "Manage languages"],
             "components": [],
             "language_selection": 1,
             "languages": [],
             "admins": [],
             "enforced_2fa": True,
-            "members": [
-                "admin"
-            ],
-            "autogroups": [
-                "^$"
-            ]
-        }
+            "members": ["admin"],
+            "autogroups": ["^$"],
+        },
     ]
     validate_schema(
         backup_with_teams,

--- a/weblate_schemas/tests/test_valid.py
+++ b/weblate_schemas/tests/test_valid.py
@@ -80,43 +80,93 @@ def test_userdata():
 
 def test_backup():
     """Test memory schema being valid."""
-    validate_schema(
-        {
-            "metadata": {
-                "version": "4.13",
-                "server": "Weblate",
-                "domain": "weblate.example.com",
-                "timestamp": "2021-11-18T18:53:54.862Z",
-            },
-            "project": {
-                "name": "Hello",
-                "slug": "hello",
-                "web": "https://weblate.org/",
-                "instructions": "",
-                "set_language_team": False,
-                "use_shared_tm": False,
-                "contribute_shared_tm": False,
-                "access_control": 0,
-                "translation_review": False,
-                "source_review": False,
-                "enable_hooks": False,
-                "language_aliases": "",
-            },
-            "labels": [],
-            "categories": [
-                {
-                    "name": "My category",
-                    "slug": "my-category",
-                    "categories": [
-                        {
-                            "name": "My Subcategory",
-                            "slug": "my-subcategory",
-                            "categories": [],
-                        }
-                    ],
-                }
-            ],
+    backup_without_teams = {
+        "metadata": {
+            "version": "4.13",
+            "server": "Weblate",
+            "domain": "weblate.example.com",
+            "timestamp": "2021-11-18T18:53:54.862Z",
         },
+        "project": {
+            "name": "Hello",
+            "slug": "hello",
+            "web": "https://weblate.org/",
+            "instructions": "",
+            "set_language_team": False,
+            "use_shared_tm": False,
+            "contribute_shared_tm": False,
+            "access_control": 0,
+            "translation_review": False,
+            "source_review": False,
+            "enable_hooks": False,
+            "language_aliases": "",
+        },
+        "labels": [],
+        "categories": [
+            {
+                "name": "My category",
+                "slug": "my-category",
+                "categories": [
+                    {
+                        "name": "My Subcategory",
+                        "slug": "my-subcategory",
+                        "categories": [],
+                    }
+                ],
+            }
+        ],
+    }
+    validate_schema(
+        backup_without_teams,
+        "weblate-backup.schema.json",
+    )
+    backup_with_teams = backup_without_teams.copy()
+    backup_with_teams["teams"] = [
+        {
+            "name": "English Translation Team",
+            "roles": [
+                "Translate"
+            ],
+            "components": [
+                "my-category/test-component",
+                "glossary"
+            ],
+            "language_selection": 0,
+            "languages": [
+                "en",
+                "en_CA",
+                "ang",
+                "en_IN",
+                "en_GB"
+            ],
+            "admins": [],
+            "enforced_2fa": False,
+            "members": [],
+            "autogroups": [
+                "^.*$"
+            ]
+        },
+        {
+            "name": "Administration",
+            "roles": [
+                "Administration",
+                "Manage languages"
+            ],
+            "components": [],
+            "language_selection": 1,
+            "languages": [],
+            "admins": [],
+            "enforced_2fa": True,
+            "members": [
+                "admin"
+            ],
+            "autogroups": [
+                "^$"
+            ]
+        }
+    ]
+    validate_schema(
+        backup_with_teams,
         "weblate-backup.schema.json",
     )
 


### PR DESCRIPTION
Backup per project access control teams as part of project backups.

The field is optional as existing backups lack this field and the schema is strict about no additional properties. Making the field required cause the schema validation to fail when importing an existing weblate backup.

Depends on #426 

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
