### PR TITLE
feat(pending): add translation id to pending unit change

### DIFF
--- a/weblate_schemas/schemas/weblate-component.schema.json
+++ b/weblate_schemas/schemas/weblate-component.schema.json
@@ -761,6 +761,7 @@
         "title": "Pending unit change data",
         "type": "object",
         "required": [
+          "translation_id",
           "unit_id_hash",
           "author",
           "target",
@@ -772,6 +773,11 @@
         ],
         "additionalProperties": false,
         "properties": {
+          "translation_id": {
+            "$id": "#root/pending_unit_changes/items/translation_id",
+            "title": "",
+            "type": "integer"
+          },
           "unit_id_hash": {
             "$id": "#root/pending_unit_changes/items/unit_id_hash",
             "title": "",

--- a/weblate_schemas/tests/test_valid.py
+++ b/weblate_schemas/tests/test_valid.py
@@ -348,6 +348,7 @@ def test_component() -> None:
         del unit["pending"]
     data["pending_unit_changes"] = [
         {
+            "translation_id": 10,
             "unit_id_hash": "1234567890abcdef",
             "author": "weblate",
             "target": "hello world",


### PR DESCRIPTION
when working on restoring pending unit changes from backups, realized that translation id is required along with id hash to uniquely identify a unit.