### PR TITLE
Add context field in the messaging schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,16 +1,12 @@
 Changelog
 =========
 
-2025.6
-------
-
-* Extended the memory to include a "context" field.
-
-
 2025.5
 ------
 
 * Extended the memory to include a "status" field.
+* Extended the memory to include a "context" field.
+* Added `context` field in the messaging schema.
 
 2025.4
 ------

--- a/weblate_schemas/messages.py
+++ b/weblate_schemas/messages.py
@@ -114,6 +114,11 @@ class WeblateV1Message(BaseMessage):
         """Return the usernames involved."""
         return sorted({name for name in (self.author, self.user) if name})
 
+    @property
+    def context(self) -> str:
+        """Return the context of the translation."""
+        return self.body.get("context")
+
     def __str__(self) -> str:
         """Return a human-readable representation of the message."""
         return f"{self.summary}"

--- a/weblate_schemas/schemas/weblate-messaging.schema.json
+++ b/weblate_schemas/schemas/weblate-messaging.schema.json
@@ -85,6 +85,10 @@
         "title": "Category slug",
         "type": "string"
       }
+    },
+    "context": {
+      "title": "Translation context or key for monolingual formats",
+      "type": "string"
     }
   }
 }

--- a/weblate_schemas/tests/test_message.py
+++ b/weblate_schemas/tests/test_message.py
@@ -6,6 +6,7 @@
 
 from weblate_schemas.messages import WeblateV1Message
 from weblate_schemas.tests.test_valid import (
+    body_with_context,
     merge_body,
     new_string_body,
     new_translation_body,
@@ -76,3 +77,18 @@ def test_weblate_new_translation_message() -> None:
         str(weblate_message)
         == "New translation event done by testuser occurred in 2019-10-17T15:57:08.772591+00:00."
     )
+
+
+def test_weblate_body_with_context_message() -> None:
+    """Test WeblateV1Message class with a body with a context field."""
+    weblate_message = WeblateV1Message(topic="test.topic", body=body_with_context)
+    assert weblate_message.change_id == body_with_context["change_id"]
+    assert weblate_message.action == body_with_context["action"]
+    assert weblate_message.timestamp == body_with_context["timestamp"]
+    assert weblate_message.url == body_with_context["url"]
+    assert weblate_message.author == body_with_context["author"]
+    assert weblate_message.user == body_with_context["user"]
+    assert weblate_message.project == body_with_context["project"]
+    assert weblate_message.translation == body_with_context["translation"]
+    assert weblate_message.source == body_with_context["source"]
+    assert weblate_message.context == body_with_context["context"]

--- a/weblate_schemas/tests/test_valid.py
+++ b/weblate_schemas/tests/test_valid.py
@@ -455,6 +455,20 @@ invalid_body = {
     "component": "test",
 }
 
+body_with_context = {
+    "change_id": 10,
+    "action": "Contributor joined",
+    "timestamp": "2025-07-15T09:30:14.898792+00:00",
+    "url": "http://example.com/translate/test/test/cs/?checksum=6412684aaf018e8e",
+    "author": "testuser",
+    "user": "testuser",
+    "project": "test",
+    "component": "test",
+    "translation": "cs",
+    "source": ["Hello, world!\n"],
+    "context": "test-context",
+}
+
 
 def test_weblate_messaging_merge() -> None:
     """Test Weblate Messaging schema to validate a repository merge event."""
@@ -502,3 +516,8 @@ def test_weblate_invalid_body() -> None:
         is_invalid = True
 
     assert is_invalid
+
+
+def test_weblate_body_with_context() -> None:
+    """Test Weblate Messaging schema to validate body with a context field."""
+    validate_schema(body_with_context, "weblate-messaging.schema.json")


### PR DESCRIPTION
This adds `context` field in the messaging schema.

```
 On instance:
    {'id': 10,
     'action': 'Contributor joined',
     'timestamp': '2025-07-15T09:30:14.898792+00:00',
     'url': 'http://example.com/translate/test/test/cs/?checksum=6412684aaf018e8e',
     'author': 'testuser',
     'user': 'testuser',
     'project': 'test',
     'component': 'test',
     'translation': 'cs',
     'source': ['Hello, world!\n'],
     'context': ''}
```
Based on the test logs for `fedora_messaging`, there are times the message body may contain `context` data. 

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
