### PR TITLE
chore: avoid listing transitive deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,7 @@ classifiers = [
   "Topic :: Utilities"
 ]
 dependencies = [
-  "fqdn>=1.5.1",
-  "jsonschema>=4.23.0",
-  "rfc3987>=1.3.8",
-  "strict-rfc3339>=0.7"
+  "jsonschema[format]>=4.24.0"
 ]
 description = "A collection of JSON schemas used by Weblate"
 keywords = [


### PR DESCRIPTION
Use jsonschema `format` extra instead of listing transitive deps manually. This proven to get out of sync, so rather depend on upstream with cost of few additional deps.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
